### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig <https://EditorConfig.org>
+root = true
+
+# elementary defaults
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+tab_width = 4
+
+# Markup files
+[{*.html,*.xml,*.xml.in,*.yml}]
+tab_width = 2


### PR DESCRIPTION
Adding an .editorconfig file will help you (and contributors) to follow the elementary spacing rules etc.
Especially for GitHub there is a need to add a final newline on each file. When the .editorconfig is set, this is made automatically on save (with most of code editors).